### PR TITLE
chore: add go fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
         types: [go]
         pass_filenames: false
 
+      - id: go-fix
+        name: go fix
+        entry: go fix ./...
+        language: system
+        types: [go]
+        pass_filenames: false
+
       - id: go-vet
         name: go vet
         entry: go vet ./...

--- a/pkg/plugin/health_test.go
+++ b/pkg/plugin/health_test.go
@@ -13,7 +13,7 @@ import (
 func newTestApp(t *testing.T, endpointURL, apiKey string) *App {
 	t.Helper()
 
-	jsonData, err := json.Marshal(map[string]interface{}{
+	jsonData, err := json.Marshal(map[string]any{
 		"endpointURL":    endpointURL,
 		"model":          "test-model",
 		"timeoutSeconds": 10,

--- a/pkg/plugin/llm.go
+++ b/pkg/plugin/llm.go
@@ -35,7 +35,7 @@ func (a *App) chatCompletion(ctx context.Context, req ChatRequest) (string, *Usa
 
 	tools := llmTools()
 
-	for round := 0; round < maxToolRounds; round++ {
+	for range maxToolRounds {
 		resp, err := a.llmClient.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
 			Model:     a.settings.Model,
 			Messages:  messages,

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -249,7 +249,7 @@ func extractUser(headers map[string][]string) string {
 	return "anonymous"
 }
 
-func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -128,7 +128,7 @@ func TestResourceChat_Success(t *testing.T) {
 		}
 
 		bodyBytes, _ := io.ReadAll(r.Body)
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		_ = json.Unmarshal(bodyBytes, &reqBody)
 
 		if reqBody["model"] != "test-model" {
@@ -218,7 +218,7 @@ func TestStreamResource_RateLimitExceeded(t *testing.T) {
 	app := newTestApp(t, "http://localhost:1/v1", "key")
 
 	// Exhaust the burst of 10
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		req := &backend.CallResourceRequest{
 			Path:    "chat/stream",
 			Method:  http.MethodPost,

--- a/pkg/plugin/security_test.go
+++ b/pkg/plugin/security_test.go
@@ -47,7 +47,7 @@ func TestSanitizePrompt_TruncatesMultiByteRunes(t *testing.T) {
 
 	// Build a string of emoji runes that exceeds maxPromptLength runes
 	var b strings.Builder
-	for i := 0; i < maxPromptLength+10; i++ {
+	for range maxPromptLength + 10 {
 		b.WriteRune('🔥') // 4 bytes each
 	}
 	got := sanitizePrompt(b.String())

--- a/pkg/plugin/streaming.go
+++ b/pkg/plugin/streaming.go
@@ -43,7 +43,7 @@ func (a *App) streamChatCompletion(ctx context.Context, req ChatRequest, sender 
 	client := a.llmClient
 	tools := llmTools()
 
-	for round := 0; round < maxToolRounds; round++ {
+	for round := range maxToolRounds {
 		ccReq := openai.ChatCompletionRequest{
 			Model:     a.settings.Model,
 			Messages:  messages,

--- a/pkg/plugin/streaming_test.go
+++ b/pkg/plugin/streaming_test.go
@@ -19,7 +19,7 @@ func TestStreamingChat_SendsSSEChunks(t *testing.T) {
 	requestCount := 0
 	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, _ := io.ReadAll(r.Body)
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		_ = json.Unmarshal(bodyBytes, &reqBody)
 		requestCount++
 
@@ -28,18 +28,18 @@ func TestStreamingChat_SendsSSEChunks(t *testing.T) {
 		if !isStream {
 			// Non-streaming: tool-check round — respond with content (no tool_calls)
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"choices": []map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{
 					{
 						"index": 0,
-						"message": map[string]interface{}{
+						"message": map[string]any{
 							"role":    "assistant",
 							"content": "Hello world!",
 						},
 						"finish_reason": "stop",
 					},
 				},
-				"usage": map[string]interface{}{
+				"usage": map[string]any{
 					"prompt_tokens":     5,
 					"completion_tokens": 3,
 				},
@@ -150,25 +150,25 @@ func TestStreamingChat_MissingPrompt(t *testing.T) {
 func TestStreamingChat_ConversationHistory(t *testing.T) {
 	t.Parallel()
 
-	var receivedMessages []interface{}
+	var receivedMessages []any
 	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, _ := io.ReadAll(r.Body)
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		_ = json.Unmarshal(bodyBytes, &reqBody)
 
 		isStream, _ := reqBody["stream"].(bool)
-		messages, _ := reqBody["messages"].([]interface{})
+		messages, _ := reqBody["messages"].([]any)
 
 		if !isStream {
 			// Capture the messages sent to the LLM for verification
 			receivedMessages = messages
 
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"choices": []map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{
 					{
 						"index": 0,
-						"message": map[string]interface{}{
+						"message": map[string]any{
 							"role":    "assistant",
 							"content": "Follow-up answer",
 						},
@@ -230,19 +230,19 @@ func TestStreamingChat_ConversationHistory(t *testing.T) {
 	}
 
 	// Check that the second message is the first history user message
-	msg1, _ := receivedMessages[1].(map[string]interface{})
+	msg1, _ := receivedMessages[1].(map[string]any)
 	if msg1["role"] != "user" || msg1["content"] != "How is the cluster?" {
 		t.Errorf("message[1] = %v, want user/How is the cluster?", msg1)
 	}
 
 	// Check that the third message is the assistant history
-	msg2, _ := receivedMessages[2].(map[string]interface{})
+	msg2, _ := receivedMessages[2].(map[string]any)
 	if msg2["role"] != "assistant" || msg2["content"] != "CPU is at 45%." {
 		t.Errorf("message[2] = %v, want assistant/CPU is at 45%%.", msg2)
 	}
 
 	// Check that the fourth message is the current prompt
-	msg3, _ := receivedMessages[3].(map[string]interface{})
+	msg3, _ := receivedMessages[3].(map[string]any)
 	if msg3["role"] != "user" || msg3["content"] != "What about memory?" {
 		t.Errorf("message[3] = %v, want user/What about memory?", msg3)
 	}
@@ -253,18 +253,18 @@ func TestStreamingChat_ReturnsTokenCounts(t *testing.T) {
 
 	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, _ := io.ReadAll(r.Body)
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		_ = json.Unmarshal(bodyBytes, &reqBody)
 
 		isStream, _ := reqBody["stream"].(bool)
 
 		if !isStream {
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"choices": []map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{
 					{
 						"index":         0,
-						"message":       map[string]interface{}{"role": "assistant", "content": "Done."},
+						"message":       map[string]any{"role": "assistant", "content": "Done."},
 						"finish_reason": "stop",
 					},
 				},
@@ -335,7 +335,7 @@ func TestStreamingChat_ToolCalling(t *testing.T) {
 	var toolResultContent string
 	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, _ := io.ReadAll(r.Body)
-		var reqBody map[string]interface{}
+		var reqBody map[string]any
 		_ = json.Unmarshal(bodyBytes, &reqBody)
 		callCount++
 
@@ -353,10 +353,10 @@ func TestStreamingChat_ToolCalling(t *testing.T) {
 		}
 
 		// Check if messages contain tool results
-		messages, _ := reqBody["messages"].([]interface{})
+		messages, _ := reqBody["messages"].([]any)
 		hasToolResult := false
 		for _, m := range messages {
-			msg, _ := m.(map[string]interface{})
+			msg, _ := m.(map[string]any)
 			if msg["role"] == "tool" {
 				hasToolResult = true
 				toolResultContent, _ = msg["content"].(string)
@@ -367,18 +367,18 @@ func TestStreamingChat_ToolCalling(t *testing.T) {
 
 		if !hasToolResult {
 			// First call: request a tool call
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"choices": []map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{
 					{
 						"index": 0,
-						"message": map[string]interface{}{
+						"message": map[string]any{
 							"role":    "assistant",
 							"content": "",
-							"tool_calls": []map[string]interface{}{
+							"tool_calls": []map[string]any{
 								{
 									"id":   "call_123",
 									"type": "function",
-									"function": map[string]interface{}{
+									"function": map[string]any{
 										"name":      "query_prometheus",
 										"arguments": `{"query":"up"}`,
 									},
@@ -391,11 +391,11 @@ func TestStreamingChat_ToolCalling(t *testing.T) {
 			})
 		} else {
 			// Second call: return content after tool results
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"choices": []map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{
 					{
 						"index": 0,
-						"message": map[string]interface{}{
+						"message": map[string]any{
 							"role":    "assistant",
 							"content": "CPU is at 45%",
 						},
@@ -412,7 +412,7 @@ func TestStreamingChat_ToolCalling(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/datasources":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"name": "Prometheus", "type": "prometheus", "uid": "prom-uid"},
 			})
 		default:

--- a/pkg/plugin/tool_executor.go
+++ b/pkg/plugin/tool_executor.go
@@ -378,15 +378,15 @@ func (te *ToolExecutor) listAlerts(ctx context.Context, arguments string, header
 
 	// If state filter requested, do client-side filtering
 	if args.State != "" {
-		var alerts []map[string]interface{}
+		var alerts []map[string]any
 		if err := json.Unmarshal([]byte(body), &alerts); err != nil {
 			return body, nil //nolint:nilerr // Return raw body if parsing fails
 		}
-		var filtered []map[string]interface{}
+		var filtered []map[string]any
 		for _, alert := range alerts {
 			if state, ok := alert["state"].(string); ok && state == args.State {
 				filtered = append(filtered, alert)
-			} else if status, ok := alert["status"].(map[string]interface{}); ok {
+			} else if status, ok := alert["status"].(map[string]any); ok {
 				if state, ok := status["state"].(string); ok && state == args.State {
 					filtered = append(filtered, alert)
 				}

--- a/pkg/plugin/tool_executor_test.go
+++ b/pkg/plugin/tool_executor_test.go
@@ -24,7 +24,7 @@ func TestToolExecutor_ListDatasources(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+		_ = json.NewEncoder(w).Encode([]map[string]any{
 			{"name": "Prometheus", "type": "prometheus", "uid": "prom-uid", "url": "http://prom:9090"},
 			{"name": "Loki", "type": "loki", "uid": "loki-uid", "url": "http://loki:3100"},
 		})
@@ -62,7 +62,7 @@ func TestToolExecutor_QueryPrometheus(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/datasources":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"name": "Prometheus", "type": "prometheus", "uid": "prom-uid"},
 			})
 		default:
@@ -72,14 +72,14 @@ func TestToolExecutor_QueryPrometheus(t *testing.T) {
 				t.Error("expected query parameter")
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"status": "success",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"resultType": "matrix",
-					"result": []map[string]interface{}{
+					"result": []map[string]any{
 						{
 							"metric": map[string]string{"instance": "node1"},
-							"values": [][]interface{}{{float64(time.Now().Unix()), "0.45"}},
+							"values": [][]any{{float64(time.Now().Unix()), "0.45"}},
 						},
 					},
 				},
@@ -100,7 +100,7 @@ func TestToolExecutor_QueryPrometheus(t *testing.T) {
 	}
 
 	// Verify it contains metric data
-	var promResp map[string]interface{}
+	var promResp map[string]any
 	if err := json.Unmarshal([]byte(result), &promResp); err != nil {
 		t.Fatalf("parse result: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestToolExecutor_NoDatasource(t *testing.T) {
 
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -190,7 +190,7 @@ func TestToolExecutor_ListDashboards(t *testing.T) {
 			t.Errorf("expected type=dash-db, got %s", r.URL.Query().Get("type"))
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+		_ = json.NewEncoder(w).Encode([]map[string]any{
 			{"title": "Kubernetes Overview", "uid": "k8s-001", "tags": []string{"kubernetes"}, "url": "/d/k8s-001"},
 			{"title": "Node Metrics", "uid": "node-001", "tags": []string{"node"}, "url": "/d/node-001"},
 		})
@@ -230,7 +230,7 @@ func TestToolExecutor_ListDashboardsWithQuery(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedQuery = r.URL.Query().Get("query")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -254,35 +254,35 @@ func TestToolExecutor_GetDashboard(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"dashboard": map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"dashboard": map[string]any{
 				"title":       "Kubernetes Overview",
 				"description": "Cluster overview dashboard",
 				"tags":        []string{"kubernetes"},
-				"panels": []map[string]interface{}{
+				"panels": []map[string]any{
 					{
 						"title": "CPU Usage",
 						"type":  "timeseries",
-						"targets": []map[string]interface{}{
+						"targets": []map[string]any{
 							{"expr": "rate(node_cpu_seconds_total[5m])", "refId": "A"},
 						},
 					},
 					{
 						"title": "Row: Storage",
 						"type":  "row",
-						"panels": []map[string]interface{}{
+						"panels": []map[string]any{
 							{
 								"title": "Disk Usage",
 								"type":  "gauge",
-								"targets": []map[string]interface{}{
+								"targets": []map[string]any{
 									{"expr": "node_filesystem_avail_bytes", "refId": "A"},
 								},
 							},
 						},
 					},
 				},
-				"templating": map[string]interface{}{
-					"list": []map[string]interface{}{
+				"templating": map[string]any{
+					"list": []map[string]any{
 						{"name": "namespace", "current": map[string]string{"text": "default", "value": "default"}},
 					},
 				},
@@ -358,13 +358,13 @@ func TestToolExecutor_ListAlerts(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/datasources":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"name": "Alertmanager", "type": "alertmanager", "uid": "am-uid"},
 			})
 		default:
 			// Alertmanager proxy endpoint
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{
 					"labels":      map[string]string{"alertname": "HighCPU", "severity": "critical", "namespace": "default"},
 					"annotations": map[string]string{"summary": "CPU usage is above 90%"},
@@ -388,7 +388,7 @@ func TestToolExecutor_ListAlerts(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	var alerts []map[string]interface{}
+	var alerts []map[string]any
 	if err := json.Unmarshal([]byte(result), &alerts); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
@@ -406,13 +406,13 @@ func TestToolExecutor_ListAlerts_WithFilter(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/datasources":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"name": "Alertmanager", "type": "alertmanager", "uid": "am-uid"},
 			})
 		default:
 			receivedFilter = r.URL.Query().Get("filter")
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
 		}
 	}))
 	defer grafanaMock.Close()
@@ -432,7 +432,7 @@ func TestToolExecutor_ListAlerts_NoAlertmanager(t *testing.T) {
 
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+		_ = json.NewEncoder(w).Encode([]map[string]any{
 			{"name": "Prometheus", "type": "prometheus", "uid": "prom-uid"},
 		})
 	}))
@@ -457,7 +457,7 @@ func TestToolExecutor_TokenPath_ReadsFromFile(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -482,7 +482,7 @@ func TestToolExecutor_TokenPath_OverridesDefaultHeaders(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -510,7 +510,7 @@ func TestToolExecutor_TokenPath_TrimsWhitespace(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -530,7 +530,7 @@ func TestToolExecutor_TokenPath_MissingFileFallsBack(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -558,7 +558,7 @@ func TestToolExecutor_TokenPath_EmptyFileFallsBack(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -586,7 +586,7 @@ func TestToolExecutor_TokenPath_PicksUpNewToken(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	}))
 	defer grafanaMock.Close()
 
@@ -623,13 +623,13 @@ func TestToolExecutor_QueryPrometheus_EscapesDsUID(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/api/datasources" {
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"name": "Prometheus", "type": "prometheus", "uid": "uid/with/../traversal"},
 			})
 		} else {
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"status": "success",
-				"data":   map[string]interface{}{"resultType": "matrix", "result": []interface{}{}},
+				"data":   map[string]any{"resultType": "matrix", "result": []any{}},
 			})
 		}
 	}))
@@ -656,16 +656,16 @@ func TestToolExecutor_ListAlerts_NoDuplicateAppend(t *testing.T) {
 	grafanaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/api/datasources" {
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"name": "AM", "type": "alertmanager", "uid": "am-uid"},
 			})
 		} else {
 			// Alert has BOTH top-level state and nested status.state
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{
 					"labels": map[string]string{"alertname": "Test"},
 					"state":  "firing",
-					"status": map[string]interface{}{"state": "firing"},
+					"status": map[string]any{"state": "firing"},
 				},
 			})
 		}
@@ -678,7 +678,7 @@ func TestToolExecutor_ListAlerts_NoDuplicateAppend(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	var alerts []map[string]interface{}
+	var alerts []map[string]any
 	if err := json.Unmarshal([]byte(result), &alerts); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -699,11 +699,11 @@ func TestToolExecutor_ListAlertRules(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string][]map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string][]map[string]any{
 			"default": {
 				{
 					"name": "HighCPU",
-					"rules": []map[string]interface{}{
+					"rules": []map[string]any{
 						{
 							"alert":  "HighCPU",
 							"expr":   "rate(node_cpu_seconds_total[5m]) > 0.9",
@@ -731,7 +731,7 @@ func TestToolExecutor_ListAlertRules(t *testing.T) {
 	}
 
 	// Verify it's valid JSON
-	var parsed interface{}
+	var parsed any
 	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
 		t.Fatalf("result is not valid JSON: %v", err)
 	}
@@ -796,7 +796,7 @@ func TestToolExecutor_DatasourceCacheHit(t *testing.T) {
 		if r.URL.Path == "/api/datasources" {
 			callCount++
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"name": "Prometheus", "type": "prometheus", "uid": "prom-uid"},
 				{"name": "Loki", "type": "loki", "uid": "loki-uid"},
 			})

--- a/pkg/plugin/tools_test.go
+++ b/pkg/plugin/tools_test.go
@@ -66,7 +66,7 @@ func TestLLMTools_PrometheusSchemaValid(t *testing.T) {
 		t.Fatal("query_prometheus tool not found")
 	}
 
-	var schema map[string]interface{}
+	var schema map[string]any
 	if err := json.Unmarshal(*promTool, &schema); err != nil {
 		t.Fatalf("invalid JSON schema: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestLLMTools_PrometheusSchemaValid(t *testing.T) {
 		t.Error("expected type=object")
 	}
 
-	props, ok := schema["properties"].(map[string]interface{})
+	props, ok := schema["properties"].(map[string]any)
 	if !ok {
 		t.Fatal("expected properties object")
 	}
@@ -84,7 +84,7 @@ func TestLLMTools_PrometheusSchemaValid(t *testing.T) {
 		t.Error("expected 'query' property")
 	}
 
-	required, ok := schema["required"].([]interface{})
+	required, ok := schema["required"].([]any)
 	if !ok {
 		t.Fatal("expected required array")
 	}


### PR DESCRIPTION
Adds a `go-fix` local hook to `.pre-commit-config.yaml` (runs `go fix ./...`) alongside the existing `go fmt` hook, and commits the resulting `go fix` modernizations.